### PR TITLE
Update dependencies 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ keywords = ["regex", "text", "generation"]
 categories = ["text-processing"]
 
 [dependencies]
-rand = "0.3.15"
-regex-syntax = "0.4.1"
-byteorder = "1.0.0"
-error-chain = "0.10.0"
+rand = "0.5.5"
+regex-syntax = "0.6.2"
+error-chain = "0.12.0"
 
 [dev-dependencies]
-regex = "0.2.2"
+regex = "1.0.0"


### PR DESCRIPTION
* Updated `rand` 0.3.15 → 0.5.5
* Updated `regex-syntax` 0.4.1 → 0.6.2

Used regex-syntax's new HIR interface introduced in 0.5. All syntax elements becomes faster, but literal becomes slower since they are now emitted character-by-character.

<details><summary>Benchmark</summary>

This version:

```
test gen_alternate ... bench:     121,423 ns/iter (+/- 12,538)
test gen_any       ... bench:     681,926 ns/iter (+/- 89,206)
test gen_class     ... bench:     891,693 ns/iter (+/- 49,692)
test gen_empty     ... bench:      25,959 ns/iter (+/- 12,414)
test gen_literal   ... bench:     128,057 ns/iter (+/- 20,601)
test gen_not_class ... bench:     914,261 ns/iter (+/- 234,728)
```

Previous master

```
test gen_alternate ... bench:     239,207 ns/iter (+/- 22,073)
test gen_any       ... bench:   1,018,183 ns/iter (+/- 68,636)
test gen_class     ... bench:   1,545,764 ns/iter (+/- 118,554)
test gen_empty     ... bench:      24,403 ns/iter (+/- 2,770)
test gen_literal   ... bench:      96,887 ns/iter (+/- 24,720)
test gen_not_class ... bench:   1,545,574 ns/iter (+/- 132,705)
```

</details>