### PR TITLE
release 0.2.2 w/rand 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex_generate"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["CryptArchy <codexarcanum@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
@CryptArchy was doing some clean up on the project where we're using this and noticed the update to rand 0.8 never got pushed to crates. It looks like you're the only one with access to push there.